### PR TITLE
Update link in README to Filet

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ docker pull filecoin/filcryo
 
 Filcryo is used to freeze chunks of the Filecoin chain with all nutritional
 properties (archival grade quality). They can then be cooked with
-[Filet](https://github.com/filecoin-project/filcryo).
+[Filet](https://github.com/filecoin-project/filet).
 
 This project first and foremost aim is to create archival-grade snapshots as
 used by the Sentinel/Data Engineering Team at Protocol Labs for further


### PR DESCRIPTION
As in the title - it appears the link from this repo to Filet is just a link back to this repo, instead of to Filet itself.